### PR TITLE
Add basic Minecraft plugin structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Gradle build artifacts
+.gradle/
+build/
+# IDE files
+.idea/
+*.iml
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# test-for
+# Minecraft Java Plugin Template
+
+This repository contains a basic template for a Minecraft (Spigot) plugin built with Gradle.
+
+## Building
+
+Ensure you have Java 21 and Gradle installed. To build the plugin JAR run:
+
+```bash
+gradle build
+```
+
+The resulting JAR will be located in `build/libs`.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.example'
+version = '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+    maven {
+        url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/'
+    }
+}
+
+dependencies {
+    compileOnly 'org.spigotmc:spigot-api:1.20.6-R0.1-SNAPSHOT'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'minecraft-plugin-template'
+

--- a/src/main/java/com/example/mcplugin/MyPlugin.java
+++ b/src/main/java/com/example/mcplugin/MyPlugin.java
@@ -1,0 +1,15 @@
+package com.example.mcplugin;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class MyPlugin extends JavaPlugin {
+    @Override
+    public void onEnable() {
+        getLogger().info("MyPlugin enabled!");
+    }
+
+    @Override
+    public void onDisable() {
+        getLogger().info("MyPlugin disabled!");
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,5 @@
+name: MyPlugin
+main: com.example.mcplugin.MyPlugin
+version: 1.0
+api-version: 1.20
+


### PR DESCRIPTION
## Summary
- clean up README with build instructions
- add Gradle build files and ignore generated directories
- implement a minimal plugin class and plugin.yml

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_683f40dd73c8833199dd502cd50b9d9b